### PR TITLE
Refactor parser to correctly identify objects

### DIFF
--- a/js/parser.js
+++ b/js/parser.js
@@ -69,30 +69,33 @@ class Parser {
     }
 
     findObject(objectTokens, availableObjects) {
-        for (const obj of availableObjects) {
-            const remainingTokens = [...objectTokens];
-            let nameMatch = false;
+        let bestMatch = null;
+        let highestScore = -1;
 
-            // Check for a name match and remove it
-            for (let i = 0; i < remainingTokens.length; i++) {
-                if (obj.names.includes(remainingTokens[i])) {
-                    nameMatch = true;
-                    remainingTokens.splice(i, 1);
-                    break; // Found a name, stop searching for names
+        for (const obj of availableObjects) {
+            const nameTokens = [];
+            const adjTokens = [];
+            const otherTokens = [];
+
+            for (const token of objectTokens) {
+                if (obj.names.includes(token)) {
+                    nameTokens.push(token);
+                } else if ((obj.adjectives || []).includes(token)) {
+                    adjTokens.push(token);
+                } else {
+                    otherTokens.push(token);
                 }
             }
 
-            if (!nameMatch) {
-                continue; // This object is not a candidate if no name matches
-            }
-
-            // Check that all remaining tokens are valid adjectives for the object
-            const adjectivesMatch = remainingTokens.every(token => obj.adjectives.includes(token));
-
-            if (adjectivesMatch) {
-                return obj; // Found a match
+            // To be a candidate, at least one name must match and there should be no unknown words.
+            if (nameTokens.length > 0 && otherTokens.length === 0) {
+                const score = nameTokens.length + adjTokens.length;
+                if (score > highestScore) {
+                    highestScore = score;
+                    bestMatch = obj;
+                }
             }
         }
-        return null; // No matching object found
+        return bestMatch;
     }
 }


### PR DESCRIPTION
The previous parser logic for finding objects was not robust. It would fail to identify objects in simple commands like 'open mailbox' and would crash if an object did not have an 'adjectives' property.

This change refactors the `findObject` method to use a scoring-based system. It now correctly handles objects with or without adjectives and more reliably identifies the intended object from the player's command.