### PR TITLE
Fix JavaScript errors preventing game from loading

### DIFF
--- a/js/actions.js
+++ b/js/actions.js
@@ -524,8 +524,7 @@ const actions = {
             return true;
         }
         return false;
-    }
-};
+    },
 
     'DBOAT-FUNCTION': (game, verb, directObject, indirectObject) => {
         if (verb === 'inflate') {
@@ -695,6 +694,7 @@ const actions = {
             return true;
         }
         return false;
-    },
+    }
+};
 
 window.gameActions = actions;

--- a/js/game.js
+++ b/js/game.js
@@ -83,7 +83,10 @@ class Game {
 
             for (const roomId in roomsData) {
                 const roomData = roomsData[roomId];
-                const objectsInRoom = roomData.objects.map(id => this.objects[id]);
+                // Filter out undefined objects that might result from bad data
+                const objectsInRoom = roomData.objects
+                    .map(id => this.objects[id])
+                    .filter(obj => obj !== undefined);
 
                 this.rooms[roomId] = new Room({
                     ...roomData,

--- a/js/parser.js
+++ b/js/parser.js
@@ -180,4 +180,6 @@ class Parser {
 }
 
 // Export the class for use in Node.js (for testing)
-module.exports = Parser;
+if (typeof module !== 'undefined') {
+    module.exports = Parser;
+}


### PR DESCRIPTION
This commit resolves three separate errors that were causing the game to fail on startup.

1.  A `ReferenceError` in `parser.js` was fixed by wrapping the `module.exports` statement in a conditional check. This allows the file to be used in both browser and Node.js environments without error.

2.  A `SyntaxError` in `actions.js` was caused by a misplaced closing brace that terminated the `actions` object prematurely. The brace has been moved to the correct position.

3.  A `TypeError` in `game.js` occurred during world loading due to inconsistent data, where a room referenced an object ID that did not exist. The code has been made more robust by filtering out any undefined objects, preventing the crash.