### PR TITLE
Fix: Use native ES modules to resolve loading errors

### DIFF
--- a/game.html
+++ b/game.html
@@ -73,19 +73,7 @@
     <div id="terminal"></div>
     <input type="text" id="input" autofocus />
 
-    <!-- Core classes must be loaded before the main game logic -->
-    <script src="js/ui.js"></script>
-    <script src="js/gameObject.js"></script>
-    <script src="js/room.js"></script>
-    <script src="js/player.js"></script>
-    <script src="js/exit.js"></script>
-    <script src="js/parser.js"></script>
-    <script src="js/actions.js"></script>
-
-    <!-- Game class uses the core classes -->
-    <script src="js/game.js"></script>
-
     <!-- Main entry point, must be last -->
-    <script src="js/main.js"></script>
+    <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -22,8 +22,8 @@ async function main() {
     const game = new Game(data);
 
     // Example of how you might handle input from a web page
-    const inputElement = document.getElementById('command-input');
-    const outputElement = document.getElementById('game-output');
+    const inputElement = document.getElementById('input');
+    const outputElement = document.getElementById('terminal');
 
     inputElement.addEventListener('keydown', (event) => {
         if (event.key === 'Enter') {
@@ -43,6 +43,6 @@ async function main() {
 }
 
 // Start the game when the DOM is ready
-// document.addEventListener('DOMContentLoaded', main);
+document.addEventListener('DOMContentLoaded', main);
 // The above line is commented out to prevent execution in the testing environment.
 // We will call main() explicitly from the test runner if needed.


### PR DESCRIPTION
The application was failing to load in the browser due to `import` and `export` statements in the JavaScript files. These were being loaded as standard scripts, which caused syntax errors.

The initial approach of using a bundler (webpack, then esbuild) failed due to environmental issues with the `npm` installation, which was unable to create the `node_modules` directory.

This commit pivots to a simpler and more direct solution:
- The `game.html` file is modified to load only the main entry point (`js/main.js`).
- The `<script>` tag is given the `type="module"` attribute.

This enables the browser's native ES module loader, which correctly parses the `import` statements and loads the application's dependencies.

Additionally, this commit reverts previous attempts to use a bundler by removing `package.json`, `webpack.config.js`, and `.gitignore`. It also ensures that the DOM element IDs in `js/main.js` match the ones in `game.html` and that the game's main function is called on `DOMContentLoaded`.