### PR TITLE
Fix: Remove duplicate data declaration in bundled game file

### DIFF
--- a/dist/game.js
+++ b/dist/game.js
@@ -2222,12 +2222,6 @@ async function main() {
         vocabulary: vocabularyData,
         deathMessages: deathMessagesData
     };
-    const data = {
-        objects: objectsData,
-        rooms: roomsData,
-        vocabulary: vocabularyData,
-        deathMessages: deathMessagesData
-    };
 
     const game = new Game(data);
 

--- a/generate_bundle.sh
+++ b/generate_bundle.sh
@@ -49,7 +49,6 @@ modified_main_content=$(echo "${original_main_content}" |
     sed '/^import/d' | # Remove import
     sed '/const data = {};/d' | # Remove old data object
     sed '/\/\/ Load all necessary data files/,/data.deathMessages = deathMessages;/d' | # Remove fetch and data assignment
-    sed 's/async function main() {/async function main() {\n    const data = {\n        objects: objectsData,\n        rooms: roomsData,\n        vocabulary: vocabularyData,\n        deathMessages: deathMessagesData\n    };/' | # Add data object
     sed '/\/\/ The above line is commented out/,/if needed./d' # Remove the comment about test runner
 )
 echo "${modified_main_content}" >> dist/game.js


### PR DESCRIPTION
The 'data' constant was being declared twice in the generated 'dist/game.js' file. This was because 'generate_bundle.sh' was injecting the declaration into 'js/main.js', which already contained it.

This commit removes the redundant injection logic from the build script, resolving the 'Uncaught SyntaxError: Identifier 'data' has already been declared' error.